### PR TITLE
Add Endpoint::withCache and deprecate Endpoint::cache

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -121,7 +121,7 @@ use ProgrammatorDev\Api\Builder\CacheBuilder;
 
 return $this
     ->endpoint()
-    ->cache(fn (CacheBuilder $cache) => $cache->defaultTtl(60))
+    ->withCache(fn (CacheBuilder $cache) => $cache->defaultTtl(60))
     ->get('/live')
     ->collection(Event::class, key: 'data');
 ```

--- a/docs/05-resources.md
+++ b/docs/05-resources.md
@@ -238,12 +238,14 @@ SDK authors can configure endpoint-specific cache defaults on the endpoint build
 ```php
 return $this
     ->endpoint()
-    ->cache(fn (CacheBuilder $cache) => $cache->defaultTtl(60))
+    ->withCache(fn (CacheBuilder $cache) => $cache->defaultTtl(60))
     ->get('/users')
     ->collection(User::class, key: 'data');
 ```
 
 Endpoint cache defaults are immutable and apply only to that request. They require API-level cache configuration because the global cache setup provides the PSR-6 pool.
+
+`Endpoint::cache()` is deprecated since version 3.2.0. Use `Endpoint::withCache()` instead.
 
 ## Resource Cache Overrides
 

--- a/docs/09-cache.md
+++ b/docs/09-cache.md
@@ -70,7 +70,7 @@ public function live(): FixtureCollection
 {
     return $this
         ->endpoint()
-        ->cache(fn (CacheBuilder $cache) => $cache->defaultTtl(60))
+        ->withCache(fn (CacheBuilder $cache) => $cache->defaultTtl(60))
         ->get('/fixtures/live')
         ->envelope(FixtureCollection::class);
 }
@@ -79,6 +79,8 @@ public function live(): FixtureCollection
 This is useful when the SDK author knows that one endpoint should behave differently from the global default. For example, realtime endpoints may default to a short TTL while stable lookup endpoints may default to a longer TTL.
 
 Endpoint defaults do not mutate the API cache builder and do not affect later requests.
+
+`Endpoint::cache()` is deprecated since version 3.2.0. Use `Endpoint::withCache()` instead.
 
 ## Resource Overrides
 

--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -23,11 +23,21 @@ class Endpoint
     /**
      * @param callable(\ProgrammatorDev\Api\Builder\CacheBuilder): mixed $configure
      */
-    public function cache(callable $configure): static
+    public function withCache(callable $configure): static
     {
         return $this->withPipelineOptions(
             $this->pipelineOptions->withDefault(PipelineOption::CACHE, $configure)
         );
+    }
+
+    /**
+     * @deprecated since 3.2.0. Use withCache().
+     *
+     * @param callable(\ProgrammatorDev\Api\Builder\CacheBuilder): mixed $configure
+     */
+    public function cache(callable $configure): static
+    {
+        return $this->withCache($configure);
     }
 
     /**

--- a/tests/Fixture/UserResource.php
+++ b/tests/Fixture/UserResource.php
@@ -57,7 +57,7 @@ class UserResource extends Resource
     {
         return $this
             ->endpoint()
-            ->cache(fn($cache) => $cache->methods(['POST']))
+            ->withCache(fn($cache) => $cache->methods(['POST']))
             ->json($data)
             ->post('/users');
     }
@@ -66,8 +66,17 @@ class UserResource extends Resource
     {
         return $this
             ->endpoint()
+            ->withCache(fn($cache) => $cache->methods(['POST']))
+            ->withCache(fn($cache) => $cache->methods(['GET']))
+            ->json($data)
+            ->post('/users');
+    }
+
+    public function createWithDeprecatedEndpointCache(array $data): Response
+    {
+        return $this
+            ->endpoint()
             ->cache(fn($cache) => $cache->methods(['POST']))
-            ->cache(fn($cache) => $cache->methods(['GET']))
             ->json($data)
             ->post('/users');
     }

--- a/tests/Integration/CacheTest.php
+++ b/tests/Integration/CacheTest.php
@@ -44,6 +44,20 @@ class CacheTest extends AbstractTestCase
         $this->assertCount(1, $client->getRequests());
     }
 
+    public function testDeprecatedEndpointCacheAliasStillConfiguresCache(): void
+    {
+        $client = $this->mockClient(new Response(body: '{"id":1,"name":"John"}'));
+        $api = new FakeApi($client);
+        $api->setup()->cache(new ArrayAdapter())->methods(['GET']);
+
+        $first = $api->users()->createWithDeprecatedEndpointCache(['name' => 'John']);
+        $second = $api->users()->createWithDeprecatedEndpointCache(['name' => 'John']);
+
+        $this->assertSame(['id' => 1, 'name' => 'John'], $first->data());
+        $this->assertSame(['id' => 1, 'name' => 'John'], $second->data());
+        $this->assertCount(1, $client->getRequests());
+    }
+
     public function testResourceCacheOverrideWinsOverEndpointCacheDefault(): void
     {
         $client = $this->mockClient(


### PR DESCRIPTION
## Summary

- Add `Endpoint::withCache()` as the preferred endpoint-level cache modifier.
- Keep `Endpoint::cache()` as a deprecated alias for compatibility.
- Update docs and upgrade examples to use `withCache()` for endpoint cache defaults.
- Add test coverage confirming the deprecated `cache()` alias still configures endpoint cache behavior.

## Migration Notes

`Endpoint::cache()` is deprecated since 3.2.0. SDK authors should use `Endpoint::withCache()` for endpoint-specific cache defaults.